### PR TITLE
Update libarchive-tools to 3.6.2-1+deb12u1

### DIFF
--- a/code-server/Dockerfile
+++ b/code-server/Dockerfile
@@ -53,7 +53,7 @@ RUN \
     \
     && apt-get install -y --no-install-recommends \
         ack=3.6.0-1 \
-        libarchive-tools=3.6.2-1 \
+        libarchive-tools=3.6.2-1+deb12u1 \
         build-essential="${build_essential_version}" \
         colordiff=1.0.20-1 \
         git=1:2.39.2-1.1 \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `libarchive-tools` to version `3.6.2-1+deb12u1` in the Docker environment for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->