### PR TITLE
Replace black with ruff

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -185,9 +185,9 @@
     },
     {
       "fileMatch": ["code-server/code-server.extensions$"],
-      "matchStrings": ["mikoz\\.black-py#(?<currentValue>.+)\\s"],
+      "matchStrings": ["charliermarsh\\.ruff#(?<currentValue>.+)\\s"],
       "datasourceTemplate": "github-tags",
-      "depNameTemplate": "34j/vscode-black"
+      "depNameTemplate": "astral-sh/ruff-vscode"
     },
     {
       "fileMatch": ["code-server/code-server.extensions$"],

--- a/code-server/code-server.extensions
+++ b/code-server/code-server.extensions
@@ -13,7 +13,7 @@ github.github-vscode-theme#6.3.5
 DavidAnson.vscode-markdownlint#0.56.0
 GitHub.copilot#1.232.0
 GitHub.copilot-chat#0.21.2024092002
-mikoz.black-py#1.0.3
+charliermarsh.ruff#2024.50.0
 github.vscode-pull-request-github#0.96.0
 ms-python.python#2024.16.0
 ms-python.debugpy#2024.10.0

--- a/code-server/requirements.txt
+++ b/code-server/requirements.txt
@@ -2,4 +2,3 @@ esphome==2024.9.2
 yamllint==1.35.1
 appdaemon==4.4.2
 hass-apps==0.20200319.0
-black==24.8.0


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `charliermarsh.ruff` extension, replacing the previous `mikoz.black-py`.
  
- **Bug Fixes**
	- Updated various extensions to their latest versions for improved performance and compatibility.

- **Chores**
	- Removed the `black` package from the requirements, streamlining dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->