### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,6 +142,8 @@ jobs:
       - lint-shellcheck
       - lint-yamllint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         architecture: ${{ fromJson(needs.information.outputs.architectures) }}


### PR DESCRIPTION
Potential fix for [https://github.com/elcajon-dev/addon-code-server/security/code-scanning/16](https://github.com/elcajon-dev/addon-code-server/security/code-scanning/16)

To fix the issue, we will add a `permissions` block to the workflow. Since the `build` job primarily involves checking out code and building a Docker image, it only requires `contents: read` permissions. This ensures that the `GITHUB_TOKEN` has the minimal permissions necessary to perform the job, reducing the risk of unintended actions.

The `permissions` block will be added at the job level for the `build` job, as this is the specific job flagged by CodeQL. If other jobs in the workflow also require explicit permissions, similar blocks can be added to those jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow permissions to enhance security for build jobs in GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->