### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -186,6 +186,9 @@ jobs:
     environment:
       name: ${{ needs.information.outputs.environment }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: 🔐 Load 1Password secrets
         uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/elcajon-dev/addon-code-server/security/code-scanning/15](https://github.com/elcajon-dev/addon-code-server/security/code-scanning/15)

To fix the issue, we will add a `permissions` block to the `publish-stable` job to explicitly define the minimum required permissions. Based on the actions performed in the job, such as dispatching repository events and accessing repository contents, the following permissions are likely required:
- `contents: read` to access repository contents.
- `actions: write` to dispatch repository events.

We will add this `permissions` block to the `publish-stable` job in the `.github/workflows/deploy.yaml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment workflow permissions for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->