### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 ---
 name: CI
-
+permissions:
+  contents: read
 # yamllint disable-line rule:truthy
 on:
   push:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,8 @@
 ---
 name: Deploy
+permissions:
+  contents: read
+  packages: write
 
 # yamllint disable-line rule:truthy
 on:

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -1,5 +1,8 @@
 ---
 name: Sync labels
+permissions:
+  contents: read
+  pull-requests: write
 
 # yamllint disable-line rule:truthy
 on:

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -1,6 +1,10 @@
 ---
 name: PR Labels
 
+permissions:
+  contents: read
+  pull-requests: write
+
 # yamllint disable-line rule:truthy
 on:
   pull_request_target:

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,6 +1,9 @@
 ---
 name: Release Drafter
 
+permissions:
+  contents: write
+
 # yamllint disable-line rule:truthy
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/elcajon-dev/addon-code-server/security/code-scanning/1](https://github.com/elcajon-dev/addon-code-server/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function. Based on the context, the workflow appears to handle pull request events and labels, so it likely requires `contents: read` and `pull-requests: write`. These permissions will allow the workflow to read repository contents and modify pull request labels without granting unnecessary write access to other resources.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
